### PR TITLE
Removed silent logging of errors on webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,7 +48,7 @@ module.exports = {
   devtool: 'cheap-module-source-map',
   devServer: {
       hot: true,
-      quiet: true,
+      quiet: false,
       disableHostCheck: true
   },
   plugins: [


### PR DESCRIPTION
quiet: true was causing issues with students not being able to compile their app if errors were present.